### PR TITLE
Added multiple alerts compatibility for SweetAlerts2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ sweetify.error(self.request, 'Some error happened here - reload the site', persi
 sweetify.warning(self.request, 'This is a warning... I guess')
 ```
 
+Additionally, you can issue multiple alerts without reloading the page **ONLY** if you are using SweetAlerts 2. To do so, you must define your options in a dictionary:
+```python
+import sweetify
+
+# Call two consecutive alerts (args1 is the options dict for the first alert and args2 the one for the second alert):
+sweetify.multiple(self.request, args1, args2)
+
+# Call five consecutive alerts:
+sweetify.multiple(self.request, args1, args2, args3, args4, args5)
+```
 ## Example Usage
 ```python
 import sweetify
@@ -64,7 +74,16 @@ def test_view(request):
     sweetify.success(request, 'You did it', text='Good job! You successfully showed a SweetAlert message', persistent='Hell yeah')
     return redirect('/')
 ```
+Example usage for multiple alerts:
+```python
+import sweetify
 
+def test_view(request):
+    args1 = dict(title='Test1', icon='info', text="Text placeholder1", button="Next")
+    args2 = dict(title='Test2', icon='success', text="Text placeholder2", timer=5000, timerProgressBar='true', persistent="Close")
+    sweetify.multiple(request, args1, args2)
+    return redirect('/')
+```
 ## Replacement for SuccessMessageMixin
 Sweetify includes a drop-in replacement for `SuccessMessageMixin`.
 Just replace the Django mixin with Sweetify's `SweetifySuccessMixin` and you are good to go.

--- a/sweetify/sweetify.py
+++ b/sweetify/sweetify.py
@@ -16,6 +16,8 @@ DEFAULT_OPTS = {
 def _flash_config(request, opts):
     request.session['sweetify'] = json.dumps(opts, cls=LazyEncoder)
 
+def _flash_multiple_configs(request, jsonData):
+    request.session['sweetify'] = jsonData
 
 def _is_string(s):
     # if we use Python 3
@@ -24,12 +26,7 @@ def _is_string(s):
     # we use Python 2
     return isinstance(s, basestring)
 
-
-def sweetalert(request, title, **kwargs):
-    opts = DEFAULT_OPTS.copy()
-    opts.update(kwargs)
-
-    opts['title'] = title
+def _treat_data(opts):
 
     button = opts.pop('button', None)
     if button:
@@ -56,7 +53,13 @@ def sweetalert(request, title, **kwargs):
             opts['button'] = opts['confirmButtonText']
         else:
             opts['button'] = False
+    return opts
 
+def sweetalert(request, title, **kwargs):
+    opts = DEFAULT_OPTS.copy()
+    opts.update(kwargs)
+    opts['title'] = title
+    opts = _treat_data(opts)    
     _flash_config(request, opts)
 
 
@@ -78,3 +81,12 @@ def error(request, title, **kwargs):
 def warning(request, title, **kwargs):
     kwargs['type'] = 'warning'
     return sweetalert(request, title, **kwargs)
+
+def multiple(request, *args):
+    optsls = []
+    for dictionary in args:
+        opts = DEFAULT_OPTS.copy()
+        opts.update(dictionary)
+        opts = _treat_data(opts)
+        optsls.append(json.dumps(opts, cls=LazyEncoder))
+    _flash_multiple_configs(request, optsls)

--- a/sweetify/templatetags/sweetify.py
+++ b/sweetify/templatetags/sweetify.py
@@ -7,17 +7,34 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def sweetify(context):
-    opts = context.request.session.pop('sweetify', None)
-    if not opts:
-        return ''
+	#TODO checkejar si es una llista, en cas afirmatiu s'ha flashejat mitjançant un multiple()
+	opts = context.request.session.pop('sweetify', None)
 
-    if getattr(settings, 'SWEETIFY_SWEETALERT_LIBRARY', 'sweetalert2') == 'sweetalert2':
-        script = 'Swal.fire({})'.format(opts)
-    else:
-        script = 'swal({})'.format(opts)
+	if not opts:
+		return ''
+	if isinstance(opts, list):
+		if getattr(settings, 'SWEETIFY_SWEETALERT_LIBRARY', 'sweetalert2') == 'sweetalert':
+			#TODO Add sweetalert 1 compatibility with multiple alerts.
+			return''
+		script = concatenate(opts)
+	else:
+		if getattr(settings, 'SWEETIFY_SWEETALERT_LIBRARY', 'sweetalert2') == 'sweetalert2':
+			script = 'Swal.fire({})'.format(opts)
+		else:
+			script = 'swal({})'.format(opts)
+	return mark_safe("""<script>{}</script>""".format(script))
 
-    return mark_safe("""
-<script>
-{}
-</script>
-""".format(script))
+def concatenate(list):
+	i = 0
+	length = len(list)
+	script = 'Swal.fire({})'
+	for opts in list:
+		if i == 0:
+			script = script.format(opts)
+			i = i + 1
+		elif i < length:
+			script += '.then((result) => {{if (result.value) {{Swal.fire({}'.format(opts)	
+			script += ')'
+	for k in range(length - 1):
+		script += '}})'
+	return script

--- a/sweetify/templatetags/sweetify.py
+++ b/sweetify/templatetags/sweetify.py
@@ -7,7 +7,6 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def sweetify(context):
-	#TODO checkejar si es una llista, en cas afirmatiu s'ha flashejat mitjançant un multiple()
 	opts = context.request.session.pop('sweetify', None)
 
 	if not opts:


### PR DESCRIPTION
As discussed in issue #9 , I've implemented a way to issue multiple alerts. To do so, the user must predefine the **kwargs of every alert as a dict and then pass all of those dicts to sweetify.multiple().
Here goes an example:
```
args1 = dict(title='Test1', icon='info', text="Text placeholder1", button="Next")
args2 = dict(title='Test2', icon='success', text="Text placeholder2", timer=5000, timerProgressBar='true', persistent="Close")
sweetify.multiple(request, args1, args2)
```
The changes made are the following:

- Added function `multiple(request, *args)` on `sweetify/sweetify.py`
- Splitted funcion `sweetalert(request, title,**kwargs)` into `sweetalert(request, title,**kwargs)` and `_treat_data(opts)` so that part of the code present in sweetalert function can be used by both sweetalert and multiple function. (`sweetify/sweetify.py`)
- Added function `_flash_multiple_configs(request, jsonData)` to flash multiple configs correctly when using the multiple function.
- Added function `concatenate(list)` on `sweetify/templatetags/sweetify.py`. This function parses the multiple alerts config and converts it to the corresponding javacript code.
- Modified function `sweetify(context)` to adapt to the changes. 

THIS MODIFICATION IS ONLY COMPATIBLE WITH **SWEETALERTS2**. If the user tries to use multiple alerts with sweetalerts1 then sweetify will not flash any javascript code.