### PR TITLE
fix CSP for inline script

### DIFF
--- a/sweetify/templatetags/sweetify.py
+++ b/sweetify/templatetags/sweetify.py
@@ -6,7 +6,7 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def sweetify(context):
+def sweetify(context, nonce=None):
     opts = context.request.session.pop("sweetify", None)
     library = getattr(settings, "SWEETIFY_SWEETALERT_LIBRARY", "sweetalert2")
 
@@ -24,9 +24,8 @@ def sweetify(context):
         else:
             script = "swal({})".format(opts)
 
-    nonce_tag = getattr(settings, "SWEETIFY_CSP_NONCE", None)
-    if nonce_tag:
-        return mark_safe("""<script nonce='{}'>{}</script>""".format(nonce_tag, script))
+    if nonce:
+        return mark_safe("""<script nonce='{}'>{}</script>""".format(nonce, script))
     else:
         return mark_safe("""<script>{}</script>""".format(script))
 

--- a/sweetify/templatetags/sweetify.py
+++ b/sweetify/templatetags/sweetify.py
@@ -24,7 +24,11 @@ def sweetify(context):
         else:
             script = "swal({})".format(opts)
 
-    return mark_safe("""<script>{}</script>""".format(script))
+    nonce_tag = getattr(settings, "SWEETIFY_CSP_NONCE", None)
+    if nonce_tag:
+        return mark_safe("""<script nonce='{}'>{}</script>""".format(nonce_tag, script))
+    else:
+        return mark_safe("""<script>{}</script>""".format(script))
 
 
 def concatenate(list):


### PR DESCRIPTION
Hi @Atrox

_"Refused to execute inline script because it violates the following Content Security Policy directive"_

I added an optional setting **SWEETIFY_CSP_NONCE** to be able to customize the **nonce tag** from app's settings because my configured CSP settings doesn't allow inline scripts.

Would you be so kind to verify and merge this in a new release?
Thanks in advance!

