### PR TITLE
fix(bug): changed deprecated method `force_text`

### DIFF
--- a/sweetify/encoder.py
+++ b/sweetify/encoder.py
@@ -1,10 +1,10 @@
 from django.core.serializers.json import DjangoJSONEncoder
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import Promise
 
 
 class LazyEncoder(DjangoJSONEncoder):
     def default(self, obj):
         if isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         return super(LazyEncoder, self).default(obj)


### PR DESCRIPTION
As Django 4.0 made its release, some features were deprecated (https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0). In particular, `django.utils.encoding.force_text()` was removed (its use had been deprecated since Django 3.0 - https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.encoding.force_text). In the current state, this method is being used in `sweetify/encoders.py` so `ImportError`s will be raised from Django 4.0 onward, as reported in #29 .

This PR solves #29 by changing `force_text` to `force_str`, method that can be used with previous versions (from Django 1.8 to Django 2.2 - https://docs.djangoproject.com/en/1.8/ref/utils/#django.utils.encoding.force_str, https://docs.djangoproject.com/en/2.2/ref/utils/#django.utils.encoding.force_str) so this fix is backwards compatible. 